### PR TITLE
Add /etc/terminfo and /lib/terminfo to the search path

### DIFF
--- a/terminfo.go
+++ b/terminfo.go
@@ -70,6 +70,12 @@ func Load(name string) (ti *Terminfo, err error) {
 			}
 		}
 	}
+	for _, dir := range []string{"/etc/terminfo", "/lib/terminfo"} {
+		ti, err = openDir(dir, name)
+		if err == nil {
+			return
+		}
+	}
 	return openDir("/usr/share/terminfo", name)
 }
 


### PR DESCRIPTION
Hi,

Apparently the man page is not quite accurate regarding the terminfo search path on Debian derivatives (https://bugs.launchpad.net/ubuntu/+source/ncurses/+bug/1098373).  I was trying to debug why your `color` package does not produce coloured output and traced it back to this issue in the `terminfo` package.

Running tests on the `color` package produces the following output:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x5e pc=0x4ff696]

goroutine 1 [running]:
panic(0x56e7e0, 0xc82000a1b0)
    /usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/nhooyr/terminfo.(*Terminfo).Color(0x0, 0x1, 0x4, 0x0, 0x0)
    /home/cell/git/go/src/github.com/nhooyr/terminfo/terminfo.go:104 +0x56
github.com/nhooyr/color.init()
    /home/cell/git/go/src/github.com/nhooyr/color/highlight_test.go:68 +0x2ca
main.init()
    github.com/nhooyr/color/_test/_testmain.go:86 +0x4a
exit status 2
```

Running tests on the `terminfo` package produces the following output:

```
--- FAIL: TestOpen (0.00s)
    terminfo_test.go:14: open /usr/share/terminfo/78/xterm: no such file or directory
```

After applying the proposed patch in this PR, tests pass on both packages and the `color` package starts producing colours again. 
